### PR TITLE
Keyword shorthand

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -535,6 +535,7 @@ dictcomp[expr_ty]:
 double_starred_kvpairs[asdl_seq*]: a=','.double_starred_kvpair+ [','] { a }
 double_starred_kvpair[KeyValuePair*]:
     | '**' a=bitwise_or { _PyPegen_key_value_pair(p, NULL, a) }
+    | ':' a=NAME {_PyPegen_key_value_shorthand(p, a)}
     | kvpair
 kvpair[KeyValuePair*]: a=expression ':' b=expression { _PyPegen_key_value_pair(p, a, b) }
 for_if_clauses[asdl_comprehension_seq*]:

--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -569,11 +569,13 @@ starred_expression[expr_ty]:
 kwarg_or_starred[KeywordOrStarred*]:
     | a=NAME '=' b=expression {
         _PyPegen_keyword_or_starred(p, CHECK(keyword_ty, _Py_keyword(a->v.Name.id, b, EXTRA)), 1) }
+    | ':' a=NAME {_PyPegen_keyword_or_starred(p, CHECK(keyword_ty, _Py_keyword(a->v.Name.id, a, EXTRA)), 1)}
     | a=starred_expression { _PyPegen_keyword_or_starred(p, a, 0) }
     | invalid_kwarg
 kwarg_or_double_starred[KeywordOrStarred*]:
     | a=NAME '=' b=expression {
         _PyPegen_keyword_or_starred(p, CHECK(keyword_ty, _Py_keyword(a->v.Name.id, b, EXTRA)), 1) }
+    | ':' a=NAME {_PyPegen_keyword_or_starred(p, CHECK(keyword_ty, _Py_keyword(a->v.Name.id, a, EXTRA)), 1)}
     | '**' a=expression { _PyPegen_keyword_or_starred(p, CHECK(keyword_ty, _Py_keyword(NULL, a, EXTRA)), 1) }
     | invalid_kwarg
 

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -12530,7 +12530,7 @@ starred_expression_rule(Parser *p)
     return _res;
 }
 
-// kwarg_or_starred: NAME '=' expression | starred_expression | invalid_kwarg
+// kwarg_or_starred: NAME '=' expression | ':' NAME | starred_expression | invalid_kwarg
 static KeywordOrStarred*
 kwarg_or_starred_rule(Parser *p)
 {
@@ -12589,6 +12589,42 @@ kwarg_or_starred_rule(Parser *p)
         D(fprintf(stderr, "%*c%s kwarg_or_starred[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "NAME '=' expression"));
     }
+    { // ':' NAME
+        if (p->error_indicator) {
+            D(p->level--);
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> kwarg_or_starred[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "':' NAME"));
+        Token * _literal;
+        expr_ty a;
+        if (
+            (_literal = _PyPegen_expect_token(p, 11))  // token=':'
+            &&
+            (a = _PyPegen_name_token(p))  // NAME
+        )
+        {
+            D(fprintf(stderr, "%*c+ kwarg_or_starred[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "':' NAME"));
+            Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
+            if (_token == NULL) {
+                D(p->level--);
+                return NULL;
+            }
+            int _end_lineno = _token->end_lineno;
+            UNUSED(_end_lineno); // Only used by EXTRA macro
+            int _end_col_offset = _token->end_col_offset;
+            UNUSED(_end_col_offset); // Only used by EXTRA macro
+            _res = _PyPegen_keyword_or_starred ( p , CHECK ( keyword_ty , _Py_keyword ( a -> v . Name . id , a , EXTRA ) ) , 1 );
+            if (_res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                D(p->level--);
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s kwarg_or_starred[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "':' NAME"));
+    }
     { // starred_expression
         if (p->error_indicator) {
             D(p->level--);
@@ -12638,7 +12674,11 @@ kwarg_or_starred_rule(Parser *p)
     return _res;
 }
 
-// kwarg_or_double_starred: NAME '=' expression | '**' expression | invalid_kwarg
+// kwarg_or_double_starred:
+//     | NAME '=' expression
+//     | ':' NAME
+//     | '**' expression
+//     | invalid_kwarg
 static KeywordOrStarred*
 kwarg_or_double_starred_rule(Parser *p)
 {
@@ -12696,6 +12736,42 @@ kwarg_or_double_starred_rule(Parser *p)
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s kwarg_or_double_starred[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "NAME '=' expression"));
+    }
+    { // ':' NAME
+        if (p->error_indicator) {
+            D(p->level--);
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> kwarg_or_double_starred[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "':' NAME"));
+        Token * _literal;
+        expr_ty a;
+        if (
+            (_literal = _PyPegen_expect_token(p, 11))  // token=':'
+            &&
+            (a = _PyPegen_name_token(p))  // NAME
+        )
+        {
+            D(fprintf(stderr, "%*c+ kwarg_or_double_starred[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "':' NAME"));
+            Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
+            if (_token == NULL) {
+                D(p->level--);
+                return NULL;
+            }
+            int _end_lineno = _token->end_lineno;
+            UNUSED(_end_lineno); // Only used by EXTRA macro
+            int _end_col_offset = _token->end_col_offset;
+            UNUSED(_end_col_offset); // Only used by EXTRA macro
+            _res = _PyPegen_keyword_or_starred ( p , CHECK ( keyword_ty , _Py_keyword ( a -> v . Name . id , a , EXTRA ) ) , 1 );
+            if (_res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                D(p->level--);
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s kwarg_or_double_starred[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "':' NAME"));
     }
     { // '**' expression
         if (p->error_indicator) {

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -11807,7 +11807,7 @@ double_starred_kvpairs_rule(Parser *p)
     return _res;
 }
 
-// double_starred_kvpair: '**' bitwise_or | kvpair
+// double_starred_kvpair: '**' bitwise_or | ':' NAME | kvpair
 static KeyValuePair*
 double_starred_kvpair_rule(Parser *p)
 {
@@ -11844,6 +11844,33 @@ double_starred_kvpair_rule(Parser *p)
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s double_starred_kvpair[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'**' bitwise_or"));
+    }
+    { // ':' NAME
+        if (p->error_indicator) {
+            D(p->level--);
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> double_starred_kvpair[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "':' NAME"));
+        Token * _literal;
+        expr_ty a;
+        if (
+            (_literal = _PyPegen_expect_token(p, 11))  // token=':'
+            &&
+            (a = _PyPegen_name_token(p))  // NAME
+        )
+        {
+            D(fprintf(stderr, "%*c+ double_starred_kvpair[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "':' NAME"));
+            _res = _PyPegen_key_value_shorthand ( p , a );
+            if (_res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                D(p->level--);
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s double_starred_kvpair[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "':' NAME"));
     }
     { // kvpair
         if (p->error_indicator) {

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -1622,6 +1622,24 @@ _PyPegen_key_value_pair(Parser *p, expr_ty key, expr_ty value)
     return a;
 }
 
+/* Constructs a KeyValuePair that is used when parsing a dict's key value pairs */
+KeyValuePair *
+_PyPegen_key_value_shorthand(Parser *p, expr_ty key)
+{
+    const char *s = PyUnicode_AsUTF8(key->v.Name.id);
+    PyObject *name = _PyPegen_new_identifier(p, s);
+    expr_ty keyname = Constant(name, NULL, key->lineno, key->col_offset, key->end_lineno, key->end_col_offset,
+                    p->arena);
+
+    KeyValuePair *a = PyArena_Malloc(p->arena, sizeof(KeyValuePair));
+    if (!a) {
+        return NULL;
+    }
+    a->key = keyname;
+    a->value = key;
+    return a;
+}
+
 /* Extracts all keys from an asdl_seq* of KeyValuePair*'s */
 asdl_expr_seq *
 _PyPegen_get_keys(Parser *p, asdl_seq *seq)

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -1626,8 +1626,8 @@ _PyPegen_key_value_pair(Parser *p, expr_ty key, expr_ty value)
 KeyValuePair *
 _PyPegen_key_value_shorthand(Parser *p, expr_ty key)
 {
-    const char *s = PyUnicode_AsUTF8(key->v.Name.id);
-    PyObject *name = _PyPegen_new_identifier(p, s);
+    PyObject *name = key->v.Name.id;
+    // TODO: need incref?
     expr_ty keyname = Constant(name, NULL, key->lineno, key->col_offset, key->end_lineno, key->end_col_offset,
                     p->arena);
 

--- a/Parser/pegen.h
+++ b/Parser/pegen.h
@@ -244,6 +244,7 @@ asdl_int_seq *_PyPegen_get_cmpops(Parser *p, asdl_seq *);
 asdl_expr_seq *_PyPegen_get_exprs(Parser *, asdl_seq *);
 expr_ty _PyPegen_set_expr_context(Parser *, expr_ty, expr_context_ty);
 KeyValuePair *_PyPegen_key_value_pair(Parser *, expr_ty, expr_ty);
+KeyValuePair *_PyPegen_key_value_shorthand(Parser *, expr_ty);
 asdl_expr_seq *_PyPegen_get_keys(Parser *, asdl_seq *);
 asdl_expr_seq *_PyPegen_get_values(Parser *, asdl_seq *);
 NameDefaultPair *_PyPegen_name_default_pair(Parser *, arg_ty, expr_ty, Token *);


### PR DESCRIPTION
support JavaScript-like keyword shorthand.

JavaScript:
```
a=100;
b=200;

{a, b}
```

Python:
```
a=100;
b=200;

{"a": a, "b": b}
```


Python(with this patch):

```
a=100;
b=200;

{:a, :b}
```

Also function call:

```
a=100;
b=200;

dict(:a, :b) -> generates {"a":100, "b": 200}
```

